### PR TITLE
abort previous AJAX request

### DIFF
--- a/jquery.autocomplete.js
+++ b/jquery.autocomplete.js
@@ -274,7 +274,10 @@
 	};
 
 	function loadRemote( url,sourceObject,done,debug ){
-		$.ajax($.extend(true,{
+		 if (sourceObject.xhr) {
+			sourceObject.xhr.abort();
+		 }
+		 sourceObject.xhr = $.ajax($.extend(true,{
 			url : url,
 			type  : 'GET' ,
 			async:true,


### PR DESCRIPTION
I faced with an issue with autocomplete from remote data. Results from previous AJAX requests arrives **after** the results from the last one sometimes. That breaks autocomplete data and leads to a wrong item selection.
Here is a solution. I used the same technique as implemented in the autocomplete of jqueryUI.
Please see https://github.com/jquery/jquery-ui/blob/master/ui/widgets/autocomplete.js#L398-L401
