### PR TITLE
fix autoselect always selecting the first suggestion

### DIFF
--- a/jquery.autocomplete.js
+++ b/jquery.autocomplete.js
@@ -784,7 +784,14 @@
 				return true;
 				case ENTER:
 					if (iOpen) {
-						$input.trigger('pick.xdsoft');
+						if (options.autoselect) {
+							$input.trigger('pick.xdsoft');
+						} else if (!options.autoselect && active) {
+							$input.trigger('pick.xdsoft');
+						} else {
+							$input.trigger('close.xdsoft');
+							return true;
+						}
 						event.preventDefault();
 						return false;
 					} else {


### PR DESCRIPTION
Setting `autoselect: false` doesn't automatically select the first suggestion item anymore.

This happened when the user didn't select any suggestion and pressed "ENTER". #22